### PR TITLE
Updated template to support deployment without SQL Server

### DIFF
--- a/ci/defaults.json
+++ b/ci/defaults.json
@@ -81,7 +81,7 @@
     },
     {
         "ParameterKey": "SIOSLicenseKeyFtpURL",
-        "ParameterValue": "http://ftp.us.sios.com/pickup/EVAL_Santiago_Cardenas_AWS_Template_Deployment_2017-06-19_DKCE/"
+        "ParameterValue": "http://ftp.us.sios.com/pickup/EVAL_Santiago_Cardenas_Sancard_2017-09-28_DKCE/"
     },
     {
         "ParameterKey": "SQLServerVersion",

--- a/ci/defaults.json
+++ b/ci/defaults.json
@@ -84,6 +84,10 @@
         "ParameterValue": "http://ftp.us.sios.com/pickup/EVAL_Santiago_Cardenas_AWS_Template_Deployment_2017-06-19_DKCE/"
     },
     {
+        "ParameterKey": "SQLServerVersion",
+        "ParameterValue": "2014SP1"
+    },
+    {
         "ParameterKey": "SQLServiceAccount",
         "ParameterValue": "sqlsa"
     },

--- a/templates/sios-datakeeper-master.template
+++ b/templates/sios-datakeeper-master.template
@@ -59,6 +59,7 @@
                     "Parameters": [
                         "AMIType",
                         "SIOSLicenseKeyFtpURL",
+                        "SQLServerVersion",
                         "SQLServiceAccount",
                         "SQLServiceAccountPassword",
                         "Volume1Size",
@@ -150,6 +151,9 @@
                 },
                 "SIOSLicenseKeyFtpURL": {
                     "default": "SIOS License Key FTP URL"
+                },
+                "SQLServerVersion": {
+                    "default": "SQL Server Version"
                 },
                 "SQLServiceAccount": {
                     "default": "Service Account Name"
@@ -396,6 +400,15 @@
         "SIOSLicenseKeyFtpURL": {
             "Default": "",
             "Description": "URL used to obtain license key for SIOS DataKeeper software.",
+            "Type": "String"
+        },
+        "SQLServerVersion": {
+            "AllowedValues": [
+                "None",
+                "2014SP1"
+            ],
+            "Default": "2014SP1",
+            "Description": "Version of MS SQL Server to install. Select 'None' if SQL Server is not desired.",
             "Type": "String"
         },
         "SQLServiceAccount": {
@@ -835,6 +848,9 @@
                     },
                     "KeyPairName": {
                         "Ref": "KeyPairName"
+                    },
+                    "SQLServerVersion": {
+                        "Ref": "SQLServerVersion"
                     },
                     "SQLServiceAccount": {
                         "Ref": "SQLServiceAccount"

--- a/templates/sios-datakeeper-master.template
+++ b/templates/sios-datakeeper-master.template
@@ -420,10 +420,10 @@
             "Type": "String"
         },
         "SQLServiceAccountPassword": {
-            "AllowedPattern": "(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*",
-            "Description": "Password for the SQL Service account. Must be at least 8 characters containing letters, numbers and symbols",
+            "AllowedPattern": "(?=^(?![\\s\\S]))|(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*",
+            "Description": "Password for the SQL Service account. Must be at least 8 characters containing letters, numbers and symbols. May be left blank if SQL Server is not desired.",
             "MaxLength": "32",
-            "MinLength": "8",
+            "MinLength": "0",
             "NoEcho": "true",
             "Type": "String"
         },

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -487,6 +487,18 @@
                     ]
                 }
             ]
+        },
+        "SQLInstallCondition": {
+            "Fn::Not": [
+                {
+                    "Fn::Equals": [
+                        {
+                            "Ref": "SQLServerVersion"
+                        },
+                        "None"
+                    ]
+                }
+            ]
         }
     },
     "Rules": {

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -476,7 +476,7 @@
                 "us-gov-west-1"
             ]
         },
-        "ByolAmi": {
+        "ByolAmiCondition": {
             "Fn::Not": [
                 {
                     "Fn::Equals": [
@@ -684,7 +684,7 @@
                             "Prep",
                             {
                                 "Fn::If": [
-                                    "ByolAmi",
+                                    "ByolAmiCondition",
                                     "DownloadDKCELicenseAndConfigure",
                                     "ConfigureDKCE"
                                 ]
@@ -1662,7 +1662,7 @@
             "Properties": {
                 "ImageId": {
                     "Fn::If": [
-                        "ByolAmi",
+                        "ByolAmiCondition",
                         {
                             "Fn::FindInMap": [
                                 "AWSAMIRegionMap",
@@ -1803,7 +1803,7 @@
                             "Prep",
                             {
                                 "Fn::If": [
-                                    "ByolAmi",
+                                    "ByolAmiCondition",
                                     "DownloadDKCELicenseAndConfigureWSFC",
                                     "ConfigureWSFC"
                                 ]
@@ -3065,7 +3065,7 @@
             "Properties": {
                 "ImageId": {
                     "Fn::If": [
-                        "ByolAmi",
+                        "ByolAmiCondition",
                         {
                             "Fn::FindInMap": [
                                 "AWSAMIRegionMap",

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -526,60 +526,88 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
+                "SIOS2012R2": "SIOS DataKeeper Cluster Edition v8.5.3 on Windows_Server-2016-English-Full-Base-2017.07.13",
                 "SIOS2012R2BYOL": "SIOS DataKeeper Cluster Edition v8.5 on Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11",
-                "SIOS2012R2SQL2014STD": "SIOS DataKeeper Cluster Edition v8.5 on Windows_Server-2012-R2_RTM-English-64Bit-SQL_2014_SP1_Standard-2017.04.12"
+                "SIOS2012R2SQL2014STD": "SIOS DataKeeper Cluster Edition v8.5 on Windows_Server-2012-R2_RTM-English-64Bit-SQL_2014_SP1_Standard-2017.04.12",
+                "SIOS2016": "SIOS DataKeeper Cluster Edition v8.5.3 on Windows_Server-2016-English-Full-Base-2017.07.13"
             },
             "us-east-1": {
+                "SIOS2012R2": "ami-befdd3a8",
                 "SIOS2012R2BYOL": "ami-a29ec1b4",
-                "SIOS2012R2SQL2014STD": "ami-c2653ad4"
+                "SIOS2012R2SQL2014STD": "ami-c2653ad4",
+                "SIOS2016": "ami-475e7551"
             },
             "us-east-2": {
+                "SIOS2012R2": "ami-2d99bf48",
                 "SIOS2012R2BYOL": "ami-68c6e00d",
-                "SIOS2012R2SQL2014STD": "ami-02f9df67"
+                "SIOS2012R2SQL2014STD": "ami-02f9df67",
+                "SIOS2016": "ami-65705100"
             },
             "us-west-1": {
+                "SIOS2012R2": "ami-dbd5f8bb",
                 "SIOS2012R2BYOL": "ami-36270556",
-                "SIOS2012R2SQL2014STD": "ami-12210372"
+                "SIOS2012R2SQL2014STD": "ami-12210372",
+                "SIOS2016": "ami-309fb250"
             },
             "us-west-2": {
+                "SIOS2012R2": "ami-382d3841",
                 "SIOS2012R2BYOL": "ami-319b9548",
-                "SIOS2012R2SQL2014STD": "ami-109b9569"
+                "SIOS2012R2SQL2014STD": "ami-109b9569",
+                "SIOS2016": "ami-956e7aec"
             },
             "ca-central-1": {
+                "SIOS2012R2": "ami-38d06f5c",
                 "SIOS2012R2BYOL": "ami-ea00bc8e",
-                "SIOS2012R2SQL2014STD": "ami-e804b88c"
+                "SIOS2012R2SQL2014STD": "ami-e804b88c",
+                "SIOS2016": "ami-abcc73cf"
             },
             "ap-south-1": {
+                "SIOS2012R2": "ami-a7d5aac8",
                 "SIOS2012R2BYOL": "ami-a4255acb",
-                "SIOS2012R2SQL2014STD": "ami-31235c5e"
+                "SIOS2012R2SQL2014STD": "ami-31235c5e",
+                "SIOS2016": "ami-bc334dd3"
             },
             "ap-northeast-2": {
+                "SIOS2012R2": "ami-dfff20b1",
                 "SIOS2012R2BYOL": "ami-f7518d99",
-                "SIOS2012R2SQL2014STD": "ami-43528e2d"
+                "SIOS2012R2SQL2014STD": "ami-43528e2d",
+                "SIOS2016": "ami-25e9364b"
             },
             "ap-southeast-1": {
+                "SIOS2012R2": "ami-5dec603e",
                 "SIOS2012R2BYOL": "ami-ee84078d",
-                "SIOS2012R2SQL2014STD": "ami-dd8605be"
+                "SIOS2012R2SQL2014STD": "ami-dd8605be",
+                "SIOS2016": "ami-9526aaf6"
             },
             "ap-southeast-2": {
+                "SIOS2012R2": "ami-ac1d0dcf",
                 "SIOS2012R2BYOL": "ami-a2daccc1",
-                "SIOS2012R2SQL2014STD": "ami-93d8cef0"
+                "SIOS2012R2SQL2014STD": "ami-93d8cef0",
+                "SIOS2016": "ami-19c6d67a"
             },
             "eu-central-1": {
+                "SIOS2012R2": "ami-d2298ebd",
                 "SIOS2012R2BYOL": "ami-c954f1a6",
-                "SIOS2012R2SQL2014STD": "ami-8755f0e8"
+                "SIOS2012R2SQL2014STD": "ami-8755f0e8",
+                "SIOS2016": "ami-ccc264a3"
             },
             "eu-west-1": {
+                "SIOS2012R2": "ami-cfdbc3a9",
                 "SIOS2012R2BYOL": "ami-54657832",
-                "SIOS2012R2SQL2014STD": "ami-40687526"
+                "SIOS2012R2SQL2014STD": "ami-40687526",
+                "SIOS2016": "ami-20051e46"
             },
             "eu-west-2": {
+                "SIOS2012R2": "ami-81786ee5",
                 "SIOS2012R2BYOL": "ami-688c9b0c",
-                "SIOS2012R2SQL2014STD": "ami-d88a9dbc"
+                "SIOS2012R2SQL2014STD": "ami-d88a9dbc",
+                "SIOS2016": "ami-e9687e8d"
             },
             "sa-east-1": {
+                "SIOS2012R2": "ami-698fe405",
                 "SIOS2012R2BYOL": "ami-e34f278f",
-                "SIOS2012R2SQL2014STD": "ami-9f4e26f3"
+                "SIOS2012R2SQL2014STD": "ami-9f4e26f3",
+                "SIOS2016": "ami-befd96d2"
             }
         }
     },

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -328,10 +328,10 @@
             "Type": "String"
         },
         "SQLServiceAccountPassword": {
-            "AllowedPattern": "(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*",
-            "Description": "Password for the SQL Service account. Must be at least 8 characters containing letters, numbers and symbols",
+            "AllowedPattern": "(?=^(?![\\s\\S]))|(?=^.{6,255}$)((?=.*\\d)(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[^A-Za-z0-9])(?=.*[a-z])|(?=.*[^A-Za-z0-9])(?=.*[A-Z])(?=.*[a-z])|(?=.*\\d)(?=.*[A-Z])(?=.*[^A-Za-z0-9]))^.*",
+            "Description": "Password for the SQL Service account. Must be at least 8 characters containing letters, numbers and symbols. May be left blank if SQL Server is not desired.",
             "MaxLength": "32",
-            "MinLength": "8",
+            "MinLength": "0",
             "NoEcho": "true",
             "Type": "String"
         },

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -729,7 +729,13 @@
                                     "ConfigureDKCE"
                                 ]
                             },
-                            "InstallSQL",
+                            {
+                                "Fn::If": [
+                                    "SQLInstallCondition",
+                                    "InstallSQL",
+                                    "DontInstallSQL"
+                                ]
+                            },
                             "Cleanup",
                             "Finalize"
                         ]
@@ -1659,6 +1665,106 @@
                             }
                         }
                     },
+                    "DontInstallSQL": {
+                        "files": {
+                            "C:\\cfn\\scripts\\WaitForCluster.ps1": {
+                                "source": {
+                                    "Fn::Sub": [
+                                        "https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/WaitForCluster.ps1",
+                                        {
+                                            "QSS3Region": {
+                                                "Fn::If": [
+                                                    "GovCloudCondition",
+                                                    "s3-us-gov-west-1",
+                                                    "s3"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "authentication": "S3AccessCreds"
+                            },
+                            "C:\\cfn\\scripts\\RegisterClusterVolume.ps1": {
+                                "source": {
+                                    "Fn::Sub": [
+                                        "https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}scripts/RegisterClusterVolume.ps1",
+                                        {
+                                            "QSS3Region": {
+                                                "Fn::If": [
+                                                    "GovCloudCondition",
+                                                    "s3-us-gov-west-1",
+                                                    "s3"
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "authentication": "S3AccessCreds"
+                            }
+                        },
+                        "commands": {
+                            "a-register-cluster-volume": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"C:\\cfn\\scripts\\RegisterClusterVolume.ps1 -Volume D ",
+                                            "\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "60"
+                            },
+                            "b-Invoke-ADReplication-DC1": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"C:\\cfn\\scripts\\Invoke-ADReplication.ps1",
+                                            " -UserName '",
+                                            {
+                                                "Ref": "DomainAdminUser"
+                                            },
+                                            "' -Password '",
+                                            {
+                                                "Ref": "DomainAdminPassword"
+                                            },
+                                            "' -DomainController '",
+                                            {
+                                                "Ref": "ADServer1NetBIOSName"
+                                            },
+                                            "'\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
+                            },
+                            "c-Invoke-ADReplication-DC2": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"C:\\cfn\\scripts\\Invoke-ADReplication.ps1",
+                                            " -UserName '",
+                                            {
+                                                "Ref": "DomainAdminUser"
+                                            },
+                                            "' -Password '",
+                                            {
+                                                "Ref": "DomainAdminPassword"
+                                            },
+                                            "' -DomainController '",
+                                            {
+                                                "Ref": "ADServer2NetBIOSName"
+                                            },
+                                            "'\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
+                            }
+                        }
+                    },
                     "Cleanup": {
                         "files": {
                             "C:\\cfn\\scripts\\DisableCredSsp.ps1": {
@@ -1713,12 +1819,26 @@
                             ]
                         },
                         {
-                            "Fn::FindInMap": [
-                                "AWSAMIRegionMap",
+                            "Fn::If": [
+                                "SQLInstallCondition",
                                 {
-                                    "Ref": "AWS::Region"
+                                    "Fn::FindInMap": [
+                                        "AWSAMIRegionMap",
+                                        {
+                                            "Ref": "AWS::Region"
+                                        },
+                                        "SIOS2012R2SQL2014STD"
+                                    ]
                                 },
-                                "SIOS2012R2SQL2014STD"
+                                {
+                                    "Fn::FindInMap": [
+                                        "AWSAMIRegionMap",
+                                        {
+                                            "Ref": "AWS::Region"
+                                        },
+                                        "SIOS2012R2"
+                                    ]
+                                }
                             ]
                         }
                     ]
@@ -1848,7 +1968,13 @@
                                     "ConfigureWSFC"
                                 ]
                             },
-                            "InstallSQL",
+                            {
+                                "Fn::If": [
+                                    "SQLInstallCondition",
+                                    "InstallSQL",
+                                    "DontInstallSQL"
+                                ]
+                            },
                             "Cleanup",
                             "Finalize"
                         ]
@@ -3062,6 +3188,58 @@
                             }
                         }
                     },
+                    "DontInstallSQL": {
+                        "commands": {
+                            "a-Invoke-ADReplication-DC1": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"C:\\cfn\\scripts\\Invoke-ADReplication.ps1",
+                                            " -UserName '",
+                                            {
+                                                "Ref": "DomainAdminUser"
+                                            },
+                                            "' -Password '",
+                                            {
+                                                "Ref": "DomainAdminPassword"
+                                            },
+                                            "' -DomainController '",
+                                            {
+                                                "Ref": "ADServer1NetBIOSName"
+                                            },
+                                            "'\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
+                            },
+                            "b-Invoke-ADReplication-DC2": {
+                                "command": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "powershell.exe -Command \"C:\\cfn\\scripts\\Invoke-ADReplication.ps1",
+                                            " -UserName '",
+                                            {
+                                                "Ref": "DomainAdminUser"
+                                            },
+                                            "' -Password '",
+                                            {
+                                                "Ref": "DomainAdminPassword"
+                                            },
+                                            "' -DomainController '",
+                                            {
+                                                "Ref": "ADServer2NetBIOSName"
+                                            },
+                                            "'\""
+                                        ]
+                                    ]
+                                },
+                                "waitAfterCompletion": "0"
+                            }
+                        }
+                    },
                     "Cleanup": {
                         "files": {
                             "C:\\cfn\\scripts\\DisableCredSsp.ps1": {
@@ -3116,12 +3294,26 @@
                             ]
                         },
                         {
-                            "Fn::FindInMap": [
-                                "AWSAMIRegionMap",
+                            "Fn::If": [
+                                "SQLInstallCondition",
                                 {
-                                    "Ref": "AWS::Region"
+                                    "Fn::FindInMap": [
+                                        "AWSAMIRegionMap",
+                                        {
+                                            "Ref": "AWS::Region"
+                                        },
+                                        "SIOS2012R2SQL2014STD"
+                                    ]
                                 },
-                                "SIOS2012R2SQL2014STD"
+                                {
+                                    "Fn::FindInMap": [
+                                        "AWSAMIRegionMap",
+                                        {
+                                            "Ref": "AWS::Region"
+                                        },
+                                        "SIOS2012R2"
+                                    ]
+                                }
                             ]
                         }
                     ]

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -47,6 +47,7 @@
                     "Parameters": [
                         "AMIType",
                         "SIOSLicenseKeyFtpURL",
+                        "SQLServerVersion",
                         "SQLServiceAccount",
                         "SQLServiceAccountPassword",
                         "Volume1Size",
@@ -132,6 +133,9 @@
                 },
                 "SIOSLicenseKeyFtpURL": {
                     "default": "SIOS License Key FTP URL"
+                },
+                "SQLServerVersion": {
+                    "default": "SQL Server Version"
                 },
                 "SQLServiceAccount": {
                     "default": "Service Account Name"
@@ -304,6 +308,15 @@
         "SIOSLicenseKeyFtpURL": {
             "Default": "",
             "Description": "URL used to obtain license key for SIOS DataKeeper software.",
+            "Type": "String"
+        },
+        "SQLServerVersion": {
+            "AllowedValues": [
+                "None",
+                "2014SP1"
+            ],
+            "Default": "2014SP1",
+            "Description": "Version of MS SQL Server to install. Select 'None' if SQL Server is not desired.",
             "Type": "String"
         },
         "SQLServiceAccount": {

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -526,59 +526,59 @@
     "Mappings": {
         "AWSAMIRegionMap": {
             "AMI": {
-                "SIOS2012R2": "SIOS DataKeeper Cluster Edition v8.5 on Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11",
+                "SIOS2012R2BYOL": "SIOS DataKeeper Cluster Edition v8.5 on Windows_Server-2012-R2_RTM-English-64Bit-Base-2017.01.11",
                 "SIOS2012R2SQL2014STD": "SIOS DataKeeper Cluster Edition v8.5 on Windows_Server-2012-R2_RTM-English-64Bit-SQL_2014_SP1_Standard-2017.04.12"
             },
             "us-east-1": {
-                "SIOS2012R2": "ami-a29ec1b4",
+                "SIOS2012R2BYOL": "ami-a29ec1b4",
                 "SIOS2012R2SQL2014STD": "ami-c2653ad4"
             },
             "us-east-2": {
-                "SIOS2012R2": "ami-68c6e00d",
+                "SIOS2012R2BYOL": "ami-68c6e00d",
                 "SIOS2012R2SQL2014STD": "ami-02f9df67"
             },
             "us-west-1": {
-                "SIOS2012R2": "ami-36270556",
+                "SIOS2012R2BYOL": "ami-36270556",
                 "SIOS2012R2SQL2014STD": "ami-12210372"
             },
             "us-west-2": {
-                "SIOS2012R2": "ami-319b9548",
+                "SIOS2012R2BYOL": "ami-319b9548",
                 "SIOS2012R2SQL2014STD": "ami-109b9569"
             },
             "ca-central-1": {
-                "SIOS2012R2": "ami-ea00bc8e",
+                "SIOS2012R2BYOL": "ami-ea00bc8e",
                 "SIOS2012R2SQL2014STD": "ami-e804b88c"
             },
             "ap-south-1": {
-                "SIOS2012R2": "ami-a4255acb",
+                "SIOS2012R2BYOL": "ami-a4255acb",
                 "SIOS2012R2SQL2014STD": "ami-31235c5e"
             },
             "ap-northeast-2": {
-                "SIOS2012R2": "ami-f7518d99",
+                "SIOS2012R2BYOL": "ami-f7518d99",
                 "SIOS2012R2SQL2014STD": "ami-43528e2d"
             },
             "ap-southeast-1": {
-                "SIOS2012R2": "ami-ee84078d",
+                "SIOS2012R2BYOL": "ami-ee84078d",
                 "SIOS2012R2SQL2014STD": "ami-dd8605be"
             },
             "ap-southeast-2": {
-                "SIOS2012R2": "ami-a2daccc1",
+                "SIOS2012R2BYOL": "ami-a2daccc1",
                 "SIOS2012R2SQL2014STD": "ami-93d8cef0"
             },
             "eu-central-1": {
-                "SIOS2012R2": "ami-c954f1a6",
+                "SIOS2012R2BYOL": "ami-c954f1a6",
                 "SIOS2012R2SQL2014STD": "ami-8755f0e8"
             },
             "eu-west-1": {
-                "SIOS2012R2": "ami-54657832",
+                "SIOS2012R2BYOL": "ami-54657832",
                 "SIOS2012R2SQL2014STD": "ami-40687526"
             },
             "eu-west-2": {
-                "SIOS2012R2": "ami-688c9b0c",
+                "SIOS2012R2BYOL": "ami-688c9b0c",
                 "SIOS2012R2SQL2014STD": "ami-d88a9dbc"
             },
             "sa-east-1": {
-                "SIOS2012R2": "ami-e34f278f",
+                "SIOS2012R2BYOL": "ami-e34f278f",
                 "SIOS2012R2SQL2014STD": "ami-9f4e26f3"
             }
         }
@@ -1681,7 +1681,7 @@
                                 {
                                     "Ref": "AWS::Region"
                                 },
-                                "SIOS2012R2"
+                                "SIOS2012R2BYOL"
                             ]
                         },
                         {
@@ -3084,7 +3084,7 @@
                                 {
                                     "Ref": "AWS::Region"
                                 },
-                                "SIOS2012R2"
+                                "SIOS2012R2BYOL"
                             ]
                         },
                         {


### PR DESCRIPTION
We created 2 new AMIs and integrated them into the template. The 2016 AMI is not currently deployed, but the region mapping is in place. There are now 2 conditionals that control which AMI is used for the cluster nodes. The already existing AMIType and a new SQLServerVersion param that can be set to 'None' or 'SQL2014SP1'. Currently end users can deploy DKCE by itself with BYOL, DKCE with SQL 2014 both with BYOL, or DKCE with SQL 2014 both with PAYG. We do not yet have an AMI to support a mismatched license model between DKCE and SQL (i.e. BYOL for one and PAYG for the other).