### PR TITLE
updated ami ids

### DIFF
--- a/scripts/install-dsc-modules.ps1
+++ b/scripts/install-dsc-modules.ps1
@@ -5,6 +5,7 @@ param()
 Set-ExecutionPolicy RemoteSigned -Force
 
 "Setting up Powershell Gallery to Install DSC Modules"
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5 -Force
 Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 

--- a/templates/sios-datakeeper.template
+++ b/templates/sios-datakeeper.template
@@ -505,110 +505,110 @@ Mappings:
       Code: SDKCEWIN2019
   AWSAMIRegionMap:
     ap-northeast-2:
-      SDKCEWIN2012R2: ami-06f2565ef03608e37
-      SDKCEWIN2012R2BYOL: ami-03516417495088685
-      SDKCEWIN2016: ami-0e977da79286a322e
-      SDKCEWIN2016BYOL: ami-00a7f00bf777ae7e6
-      SDKCEWIN2019: ami-0701531bf9360dd6a
-      SDKCEWIN2019BYOL: ami-0140c683f2cbe3434
+      SDKCEWIN2012R2: ami-00e8dd618d95c17e1
+      SDKCEWIN2012R2BYOL: ami-01b5b1ef5541a524f
+      SDKCEWIN2016: ami-0467101d55850b416
+      SDKCEWIN2016BYOL: ami-0f0a91c23cc9978e2
+      SDKCEWIN2019: ami-03c6854a0a4721729
+      SDKCEWIN2019BYOL: ami-0cfcab44a6b5d8696
     ap-south-1:
-      SDKCEWIN2012R2: ami-06f60f8e8093c6651
-      SDKCEWIN2012R2BYOL: ami-0d63ee5523d0c44a8
-      SDKCEWIN2016: ami-03095701723e8e191
-      SDKCEWIN2016BYOL: ami-06023c681ee1b9fa7
-      SDKCEWIN2019: ami-0ae89ffebebfea725
-      SDKCEWIN2019BYOL: ami-05d7f8c6e81fad3af
+      SDKCEWIN2012R2: ami-06208985f3bccc44a
+      SDKCEWIN2012R2BYOL: ami-074a3df8fbc78b7f9
+      SDKCEWIN2016: ami-071d7ca01686c56e9
+      SDKCEWIN2016BYOL: ami-03cab67895caa2a36
+      SDKCEWIN2019: ami-0aaa84b914d4056ec
+      SDKCEWIN2019BYOL: ami-0f67db0c6dbd04225
     ap-southeast-1:
-      SDKCEWIN2012R2: ami-03a5524f1ff32a048
-      SDKCEWIN2012R2BYOL: ami-0e02e1cd431ad0b26
-      SDKCEWIN2016: ami-0973d65b7688ac5ee
-      SDKCEWIN2016BYOL: ami-0659b392a76f20a94
-      SDKCEWIN2019: ami-03f0b21ce66ad3803
-      SDKCEWIN2019BYOL: ami-07de62254f394eab4
+      SDKCEWIN2012R2: ami-0bc161ccb819c515e
+      SDKCEWIN2012R2BYOL: ami-000e342cf14c846cd
+      SDKCEWIN2016: ami-08a3092603b346375
+      SDKCEWIN2016BYOL: ami-05ac57bde4add69ab
+      SDKCEWIN2019: ami-0e1fca62e9a68be25
+      SDKCEWIN2019BYOL: ami-08c0e868d2efe0e54
     ap-southeast-2:
-      SDKCEWIN2012R2: ami-053806398ea2a79e4
-      SDKCEWIN2012R2BYOL: ami-028e157e884ab1dec
-      SDKCEWIN2016: ami-0ad539351d7d8de9b
-      SDKCEWIN2016BYOL: ami-069c329196f311363
-      SDKCEWIN2019: ami-0cc5893644ddf557e
-      SDKCEWIN2019BYOL: ami-06eab46f74f64b6ec
+      SDKCEWIN2012R2: ami-0d60d62e644d2788d
+      SDKCEWIN2012R2BYOL: ami-0313df2205977c76f
+      SDKCEWIN2016: ami-01aaf2b363b4d4955
+      SDKCEWIN2016BYOL: ami-01643a6caf623bcae
+      SDKCEWIN2019: ami-0f591a544f62a649c
+      SDKCEWIN2019BYOL: ami-01b0ee2f07596111e
     ca-central-1:
-      SDKCEWIN2012R2: ami-08e16751ddec7be09
-      SDKCEWIN2012R2BYOL: ami-0064aa23b73cce907
-      SDKCEWIN2016: ami-0f919f49d415fca5b
-      SDKCEWIN2016BYOL: ami-03dcac8cab455e81b
-      SDKCEWIN2019: ami-053e36dfd8c42d487
-      SDKCEWIN2019BYOL: ami-0ecf8fe07e16e86c2
+      SDKCEWIN2012R2: ami-00d70ee387ff84726
+      SDKCEWIN2012R2BYOL: ami-068e8a6f6ca017973
+      SDKCEWIN2016: ami-01921c1af84422aa6
+      SDKCEWIN2016BYOL: ami-0ee33c0bc13118c90
+      SDKCEWIN2019: ami-07bbb94a7efcca619
+      SDKCEWIN2019BYOL: ami-0e12a46fd961240ef
     eu-central-1:
-      SDKCEWIN2012R2: ami-054862ea69bce2f83
-      SDKCEWIN2012R2BYOL: ami-03b29f6d9c38dae49
-      SDKCEWIN2016: ami-0acefe544437c356b
-      SDKCEWIN2016BYOL: ami-069618b12b258c4dc
-      SDKCEWIN2019: ami-04266f0991f0e70c4
-      SDKCEWIN2019BYOL: ami-096d67f89796dfb64
+      SDKCEWIN2012R2: ami-09eec42830de24267
+      SDKCEWIN2012R2BYOL: ami-0b16f0725bb9ae417
+      SDKCEWIN2016: ami-0ece4adc69d59b4c8
+      SDKCEWIN2016BYOL: ami-09c87e6461d789849
+      SDKCEWIN2019: ami-0b7c623d5acf529e5
+      SDKCEWIN2019BYOL: ami-02390b7ea95f07079
     eu-north-1:
-      SDKCEWIN2012R2: ami-0191130dd4f744786
-      SDKCEWIN2012R2BYOL: ami-04bce219582ebe58d
-      SDKCEWIN2016: ami-06b4daa0d226b2082
-      SDKCEWIN2016BYOL: ami-00a1568218d846b2f
-      SDKCEWIN2019: ami-0fa4cad9d763029a5
-      SDKCEWIN2019BYOL: ami-006d6c2767fb6ea75
+      SDKCEWIN2012R2: ami-048b53b3bd7e8052c
+      SDKCEWIN2012R2BYOL: ami-00f7a87ab3af9d9dd
+      SDKCEWIN2016: ami-0a1fd2b74e5ed4ae3
+      SDKCEWIN2016BYOL: ami-08e903120d983b130
+      SDKCEWIN2019: ami-07badcd2c4d8a3ad7
+      SDKCEWIN2019BYOL: ami-02496e9af4dd18eda
     eu-west-1:
-      SDKCEWIN2012R2: ami-0f2fd76c51a759f59
-      SDKCEWIN2012R2BYOL: ami-09e8b34d26a729f38
-      SDKCEWIN2016: ami-06b40d380442856bf
-      SDKCEWIN2016BYOL: ami-07af265ea539f2731
-      SDKCEWIN2019: ami-0a25e56e2caf18505
-      SDKCEWIN2019BYOL: ami-02adbfd377ed997bf
+      SDKCEWIN2012R2: ami-0d0891f874b02ffd7
+      SDKCEWIN2012R2BYOL: ami-09583316cafafe4f5
+      SDKCEWIN2016: ami-046a6d1ed41071653
+      SDKCEWIN2016BYOL: ami-076c70250c97c8599
+      SDKCEWIN2019: ami-0046d5aefa67d3b2a
+      SDKCEWIN2019BYOL: ami-0ab997d5d2dfa3224
     eu-west-2:
-      SDKCEWIN2012R2: ami-0ca99107a2735b116
-      SDKCEWIN2012R2BYOL: ami-0dd3432fb55d37737
-      SDKCEWIN2016: ami-0a5980f8602aac7ff
-      SDKCEWIN2016BYOL: ami-056e3fcc742c523b0
-      SDKCEWIN2019: ami-0de6365046b3680a2
-      SDKCEWIN2019BYOL: ami-09362c652f6a2c900
+      SDKCEWIN2012R2: ami-0e9f7dbab7c0d6150
+      SDKCEWIN2012R2BYOL: ami-001de07335564d369
+      SDKCEWIN2016: ami-0621035ea387fdbb6
+      SDKCEWIN2016BYOL: ami-0e48dbaac5adc2821
+      SDKCEWIN2019: ami-07cef6c38ac216270
+      SDKCEWIN2019BYOL: ami-00b0fc2ba2940c2eb
     eu-west-3:
-      SDKCEWIN2012R2: ami-0231a8b6daae5c83f
-      SDKCEWIN2012R2BYOL: ami-060a6ea922b550780
-      SDKCEWIN2016: ami-07f43ac21e1bca616
-      SDKCEWIN2016BYOL: ami-05193c6d5211c4827
-      SDKCEWIN2019: ami-04cfff53188a91a7a
-      SDKCEWIN2019BYOL: ami-0fae282b3dfa69dbb
+      SDKCEWIN2012R2: ami-0469b8284541f3508
+      SDKCEWIN2012R2BYOL: ami-012aa046dba3f95c0
+      SDKCEWIN2016: ami-0e49ae60741aca728
+      SDKCEWIN2016BYOL: ami-0f6da6276cc216e9c
+      SDKCEWIN2019: ami-0ad9e1a9c0e7a030a
+      SDKCEWIN2019BYOL: ami-0eb39402f6a9b621c
     sa-east-1:
-      SDKCEWIN2012R2: ami-017eec8ab74872a15
-      SDKCEWIN2012R2BYOL: ami-01a449c3a9d1f04cb
-      SDKCEWIN2016: ami-06a583cafcf689b3e
-      SDKCEWIN2016BYOL: ami-0b24fd3a7021b8b2f
-      SDKCEWIN2019: ami-0013929b981e747e9
-      SDKCEWIN2019BYOL: ami-08f63fd6ed5de98a6
+      SDKCEWIN2012R2: ami-0c19069df007fc3bb
+      SDKCEWIN2012R2BYOL: ami-0bc34d5ddd3e2ba4c
+      SDKCEWIN2016: ami-038932a66d7326657
+      SDKCEWIN2016BYOL: ami-08efef5654682f218
+      SDKCEWIN2019: ami-0ef017dfaee1f747b
+      SDKCEWIN2019BYOL: ami-0c752621d378ee407
     us-east-1:
-      SDKCEWIN2012R2: ami-0d213d3472495928f
-      SDKCEWIN2012R2BYOL: ami-0af510038d1977752
-      SDKCEWIN2016: ami-0773e8d74659e4a0c
-      SDKCEWIN2016BYOL: ami-069ab4098e5bc2b6b
-      SDKCEWIN2019: ami-0c1b6862afc7fa5c9
-      SDKCEWIN2019BYOL: ami-087bc32034f4a43c6
+      SDKCEWIN2012R2: ami-0c5f7ada3d24364d4
+      SDKCEWIN2012R2BYOL: ami-01e9b7b9cf5e68366
+      SDKCEWIN2016: ami-02007f1e0aea17d79
+      SDKCEWIN2016BYOL: ami-05432f04d4c78da81
+      SDKCEWIN2019: ami-01f7c66119ffe289a
+      SDKCEWIN2019BYOL: ami-0729b6cc3e5fd11ab
     us-east-2:
-      SDKCEWIN2012R2: ami-0fcdeb2fe4a4ed795
-      SDKCEWIN2012R2BYOL: ami-0ce93e853e1a47bbb
-      SDKCEWIN2016: ami-05638d65d1784622a
-      SDKCEWIN2016BYOL: ami-0eab322542fbdfb38
-      SDKCEWIN2019: ami-0987e9c8a3193e592
-      SDKCEWIN2019BYOL: ami-0d563d7703aac56ca
+      SDKCEWIN2012R2: ami-0e96e3423e68d4f76
+      SDKCEWIN2012R2BYOL: ami-0332e3dfc725ce518
+      SDKCEWIN2016: ami-0924e7816d2c91b67
+      SDKCEWIN2016BYOL: ami-09f092fcf8377fed0
+      SDKCEWIN2019: ami-0bb5979baa21b1a67
+      SDKCEWIN2019BYOL: ami-07547ffdf3399a823
     us-west-1:
-      SDKCEWIN2012R2: ami-0f04104e1335dd37b
-      SDKCEWIN2012R2BYOL: ami-0b5c886a41f7332b4
-      SDKCEWIN2016: ami-06c590ba1bc46b955
-      SDKCEWIN2016BYOL: ami-0953a0aa0fb6bbbfc
-      SDKCEWIN2019: ami-01b6bf844bed1551d
-      SDKCEWIN2019BYOL: ami-0e10d0d71fe47bef7
+      SDKCEWIN2012R2: ami-0986bfb9c42fba3dd
+      SDKCEWIN2012R2BYOL: ami-0f5798a79860ddef2
+      SDKCEWIN2016: ami-09eb35281ca5df9a2
+      SDKCEWIN2016BYOL: ami-01aa1864f054a93aa
+      SDKCEWIN2019: ami-0951f3e6234322a30
+      SDKCEWIN2019BYOL: ami-0175f4bd2410d2452
     us-west-2:
-      SDKCEWIN2012R2: ami-027b2a76e12a2beb7
-      SDKCEWIN2012R2BYOL: ami-00db04dac2c592911
-      SDKCEWIN2016: ami-078408ec5ecae7410
-      SDKCEWIN2016BYOL: ami-0bfe889ba173aa1e9
-      SDKCEWIN2019: ami-05d056f3d434cd953
-      SDKCEWIN2019BYOL: ami-0405f91e0c43ab94d
+      SDKCEWIN2012R2: ami-016fe5555971f0eb5
+      SDKCEWIN2012R2BYOL: ami-09af4088a7bc4b4dc
+      SDKCEWIN2016: ami-063090b5434a4b972
+      SDKCEWIN2016BYOL: ami-08d480951c09923ba
+      SDKCEWIN2019: ami-03f02f78c2467a3c6
+      SDKCEWIN2019BYOL: ami-0e4e9295a7cb1ed6c
 Resources:
   QuickStartLogs:
     Type: AWS::Logs::LogGroup
@@ -633,7 +633,7 @@ Resources:
            description: Windows Server OS version to use for cluster nodes.
            type: String
           ADServer1NetBIOSName:
-           default: DC1
+           default: SIOSDC1
            description: NetBIOS name of the first Active Directory server (up to 15 characters)
            type: String
           ADServer1PrivateIP: 
@@ -641,7 +641,7 @@ Resources:
            description: Fixed private IP for the first Active Directory server located in Availability Zone 1
            type: String
           ADServer2NetBIOSName:
-           default: DC2
+           default: SIOSDC2
            description: NetBIOS name of the second Active Directory server (up to 15 characters)
            type: String
           ADServer2PrivateIP:
@@ -793,6 +793,21 @@ Resources:
             Filters:  
             - Name: tag:Name
               Values: [ '{{ADServer1NetBIOSName}}' ]
+            - Name: instance-state-name
+              Values: [ 'running' ]
+          outputs:
+          - Name: InstanceId
+            Selector: $.Reservations[0].Instances[0].InstanceId
+            Type: String
+        - name: dc2InstanceId
+          action: aws:executeAwsApi
+          onFailure: step:signalfailure
+          inputs:
+            Service: ec2
+            Api: DescribeInstances
+            Filters:  
+            - Name: tag:Name
+              Values: [ '{{ADServer2NetBIOSName}}' ]
             - Name: instance-state-name
               Values: [ 'running' ]
           outputs:
@@ -1136,6 +1151,9 @@ Resources:
             Parameters:
               commands: 
                 - |
+                   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+                   Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5 -Force
+                   Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
                    Install-Module -Name xSmbShare
                    Install-Module -Name PSDscResources
         - name: configureWSFCFileShare
@@ -1156,30 +1174,30 @@ Resources:
           action: aws:runCommand
           onFailure: step:signalfailure
           inputs:
-            DocumentName: AWS-RunRemoteScript
-            InstanceIds:
-              - '{{wsfcnode2InstanceId.InstanceId}}'
+            DocumentName: AWS-RunPowerShellScript
+            InstanceIds: 
+              - '{{dc1InstanceId.InstanceId}}'
             CloudWatchOutputConfig:
               CloudWatchOutputEnabled: 'true'
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
-              sourceType: S3
-              sourceInfo: '{"path": "https://s3.amazonaws.com/{{QSS3BucketName}}/{{QSS3KeyPrefix}}submodules/quickstart-microsoft-utilities/scripts/Invoke-ADReplication.ps1"}'
-              commandLine: ./Invoke-ADReplication.ps1 -UserName {{DomainAdminUser}} -Password {{DomainAdminPassword}} -DomainController {{ADServer1NetBIOSName}}
+              commands: 
+                - |
+                   repadmin /syncall /A /e /P
         - name: InvokeADReplicationDC2
           action: aws:runCommand
           onFailure: step:signalfailure
           inputs:
-            DocumentName: AWS-RunRemoteScript
-            InstanceIds:
-              - '{{wsfcnode2InstanceId.InstanceId}}'
+            DocumentName: AWS-RunPowerShellScript
+            InstanceIds: 
+              - '{{dc2InstanceId.InstanceId}}'
             CloudWatchOutputConfig:
               CloudWatchOutputEnabled: 'true'
               CloudWatchLogGroupName: !Ref QuickStartLogs
             Parameters:
-              sourceType: S3
-              sourceInfo: '{"path": "https://s3.amazonaws.com/{{QSS3BucketName}}/{{QSS3KeyPrefix}}submodules/quickstart-microsoft-utilities/scripts/Invoke-ADReplication.ps1"}'
-              commandLine: ./Invoke-ADReplication.ps1 -UserName {{DomainAdminUser}} -Password {{DomainAdminPassword}} -DomainController {{ADServer2NetBIOSName}}
+              commands: 
+                - |
+                   repadmin /syncall /A /e /P
         - name: WSFCConfigureBranch
           action: aws:branch
           inputs:


### PR DESCRIPTION
Updated for our recent 8.7.1 release.

For some reason certain things stopped working on 2012R2. One of those was downloading NuGet packages. Fix was to set the version of TLS to use just before attempting the download.

Changed the way we were forcing a domain sync also. We had been doing it via a remote script, but that was just left over from when the template was using cfn. Now that it's using ssm I stopped using a remote script in favor of running a single command directly on the domain controller.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
